### PR TITLE
New @import build process

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "bower_components"
+  "directory": "src/vendor"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,27 +73,24 @@ module.exports = function(grunt) {
       // Compile src/cf-grid.less for the docs.
       src: {
         options: {
-          paths: grunt.file.expand('src'),
-          sourceMap: false
+          paths: grunt.file.expand('src/vendor/**'),
+          sourceMap: true,
+          sourceMapRootpath: '/'
         },
         files: {
           'docs/static/css/main.css': [
-            'src/vendor/normalize-css/normalize.css',
-            'src/vendor/normalize-legacy-addon/normalize-legacy-addon.css',
-            'src/cf-grid.less'
+            'src/cf-*.less'
           ]
         }
       },
       // Compile a version of cf-grids for CSS use.
       generated: {
         options: {
-          paths: grunt.file.expand('src'),
+          paths: grunt.file.expand('src/vendor/**'),
           sourceMap: false
         },
         files: {
           'src-generated/cf-grid-generated.css': [
-            'src/vendor/normalize-css/normalize.css',
-            'src/vendor/normalize-legacy-addon/normalize-legacy-addon.css',
             'src-generated/cf-grid-generated.less'
           ]
         }
@@ -101,13 +98,11 @@ module.exports = function(grunt) {
       // Compile a version of cf-grid-generated.less for the custom demo.
       'custom-demo': {
         options: {
-          paths: grunt.file.expand('src','src-generated'),
+          paths: grunt.file.expand('src/vendor/**','src-generated'),
           sourceMap: false
         },
         files: {
           'custom-demo/static/css/custom-demo.css': [
-            'src/vendor/normalize-css/normalize.css',
-            'src/vendor/normalize-legacy-addon/normalize-legacy-addon.css',
             'custom-demo/static/css/custom-demo.less'
           ]
         }
@@ -155,7 +150,7 @@ module.exports = function(grunt) {
   /**
    * Create custom task aliases for our component build workflow.
    */
-  grunt.registerTask('vendor', ['bower', 'copy:boxsizing']);
+  grunt.registerTask('vendor', ['copy:boxsizing']);
   grunt.registerTask('default', ['less:src', 'less:generated', 'less:custom-demo', 'autoprefixer', 'topdoc:docs']);
 
 };

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-grid",
-  "version": "0.9.3",
+  "version": "1.0.0",
   "description": "A Less-based grid system using parametric mixins. Part of Capital Framework.",
   "keywords": [
     "capital-framework",

--- a/custom-demo/static/css/custom-demo.css
+++ b/custom-demo/static/css/custom-demo.css
@@ -1,559 +1,3 @@
-/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
-/**
- * 1. Set default font family to sans-serif.
- * 2. Prevent iOS text size adjust after orientation change, without disabling
- *    user zoom.
- */
-html {
-  font-family: sans-serif;
-  /* 1 */
-  -ms-text-size-adjust: 100%;
-  /* 2 */
-  -webkit-text-size-adjust: 100%;
-  /* 2 */
-}
-/**
- * Remove default margin.
- */
-body {
-  margin: 0;
-}
-/* HTML5 display definitions
-   ========================================================================== */
-/**
- * Correct `block` display not defined for any HTML5 element in IE 8/9.
- * Correct `block` display not defined for `details` or `summary` in IE 10/11
- * and Firefox.
- * Correct `block` display not defined for `main` in IE 11.
- */
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-main,
-menu,
-nav,
-section,
-summary {
-  display: block;
-}
-/**
- * 1. Correct `inline-block` display not defined in IE 8/9.
- * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
- */
-audio,
-canvas,
-progress,
-video {
-  display: inline-block;
-  /* 1 */
-  vertical-align: baseline;
-  /* 2 */
-}
-/**
- * Prevent modern browsers from displaying `audio` without controls.
- * Remove excess height in iOS 5 devices.
- */
-audio:not([controls]) {
-  display: none;
-  height: 0;
-}
-/**
- * Address `[hidden]` styling not present in IE 8/9/10.
- * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
- */
-[hidden],
-template {
-  display: none;
-}
-/* Links
-   ========================================================================== */
-/**
- * Remove the gray background color from active links in IE 10.
- */
-a {
-  background-color: transparent;
-}
-/**
- * Improve readability when focused and also mouse hovered in all browsers.
- */
-a:active,
-a:hover {
-  outline: 0;
-}
-/* Text-level semantics
-   ========================================================================== */
-/**
- * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
- */
-abbr[title] {
-  border-bottom: 1px dotted;
-}
-/**
- * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
- */
-b,
-strong {
-  font-weight: bold;
-}
-/**
- * Address styling not present in Safari and Chrome.
- */
-dfn {
-  font-style: italic;
-}
-/**
- * Address variable `h1` font-size and margin within `section` and `article`
- * contexts in Firefox 4+, Safari, and Chrome.
- */
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
-}
-/**
- * Address styling not present in IE 8/9.
- */
-mark {
-  background: #ff0;
-  color: #000;
-}
-/**
- * Address inconsistent and variable font size in all browsers.
- */
-small {
-  font-size: 80%;
-}
-/**
- * Prevent `sub` and `sup` affecting `line-height` in all browsers.
- */
-sub,
-sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
-sup {
-  top: -0.5em;
-}
-sub {
-  bottom: -0.25em;
-}
-/* Embedded content
-   ========================================================================== */
-/**
- * Remove border when inside `a` element in IE 8/9/10.
- */
-img {
-  border: 0;
-}
-/**
- * Correct overflow not hidden in IE 9/10/11.
- */
-svg:not(:root) {
-  overflow: hidden;
-}
-/* Grouping content
-   ========================================================================== */
-/**
- * Address margin not present in IE 8/9 and Safari.
- */
-figure {
-  margin: 1em 40px;
-}
-/**
- * Address differences between Firefox and other browsers.
- */
-hr {
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
-  height: 0;
-}
-/**
- * Contain overflow in all browsers.
- */
-pre {
-  overflow: auto;
-}
-/**
- * Address odd `em`-unit font size rendering in all browsers.
- */
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace, monospace;
-  font-size: 1em;
-}
-/* Forms
-   ========================================================================== */
-/**
- * Known limitation: by default, Chrome and Safari on OS X allow very limited
- * styling of `select`, unless a `border` property is set.
- */
-/**
- * 1. Correct color not being inherited.
- *    Known issue: affects color of disabled elements.
- * 2. Correct font properties not being inherited.
- * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
- */
-button,
-input,
-optgroup,
-select,
-textarea {
-  color: inherit;
-  /* 1 */
-  font: inherit;
-  /* 2 */
-  margin: 0;
-  /* 3 */
-}
-/**
- * Address `overflow` set to `hidden` in IE 8/9/10/11.
- */
-button {
-  overflow: visible;
-}
-/**
- * Address inconsistent `text-transform` inheritance for `button` and `select`.
- * All other form control elements do not inherit `text-transform` values.
- * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
- * Correct `select` style inheritance in Firefox.
- */
-button,
-select {
-  text-transform: none;
-}
-/**
- * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
- *    and `video` controls.
- * 2. Correct inability to style clickable `input` types in iOS.
- * 3. Improve usability and consistency of cursor style between image-type
- *    `input` and others.
- */
-button,
-html input[type="button"],
-input[type="reset"],
-input[type="submit"] {
-  -webkit-appearance: button;
-  /* 2 */
-  cursor: pointer;
-  /* 3 */
-}
-/**
- * Re-set default cursor for disabled elements.
- */
-button[disabled],
-html input[disabled] {
-  cursor: default;
-}
-/**
- * Remove inner padding and border in Firefox 4+.
- */
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
-  padding: 0;
-}
-/**
- * Address Firefox 4+ setting `line-height` on `input` using `!important` in
- * the UA stylesheet.
- */
-input {
-  line-height: normal;
-}
-/**
- * It's recommended that you don't attempt to style these elements.
- * Firefox's implementation doesn't respect box-sizing, padding, or width.
- *
- * 1. Address box sizing set to `content-box` in IE 8/9/10.
- * 2. Remove excess padding in IE 8/9/10.
- */
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box;
-  /* 1 */
-  padding: 0;
-  /* 2 */
-}
-/**
- * Fix the cursor style for Chrome's increment/decrement buttons. For certain
- * `font-size` values of the `input`, it causes the cursor style of the
- * decrement button to change from `default` to `text`.
- */
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  height: auto;
-}
-/**
- * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
- * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
- *    (include `-moz` to future-proof).
- */
-input[type="search"] {
-  -webkit-appearance: textfield;
-  /* 1 */
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box;
-  /* 2 */
-  box-sizing: content-box;
-}
-/**
- * Remove inner padding and search cancel button in Safari and Chrome on OS X.
- * Safari (but not Chrome) clips the cancel button when the search input has
- * padding (and `textfield` appearance).
- */
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-/**
- * Define consistent border, margin, and padding.
- */
-fieldset {
-  border: 1px solid #c0c0c0;
-  margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em;
-}
-/**
- * 1. Correct `color` not being inherited in IE 8/9/10/11.
- * 2. Remove padding so people aren't caught out if they zero out fieldsets.
- */
-legend {
-  border: 0;
-  /* 1 */
-  padding: 0;
-  /* 2 */
-}
-/**
- * Remove default vertical scrollbar in IE 8/9/10/11.
- */
-textarea {
-  overflow: auto;
-}
-/**
- * Don't inherit the `font-weight` (applied by a rule above).
- * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
- */
-optgroup {
-  font-weight: bold;
-}
-/* Tables
-   ========================================================================== */
-/**
- * Remove most spacing between table cells.
- */
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-td,
-th {
-  padding: 0;
-}
-
-/*! normalize-legacy-addon | MIT License | https://github.com/cfpb/normalize-legacy-addon */
-/* ==========================================================================
-   HTML5 display definitions
-   ========================================================================== */
-/*
- * Corrects `inline-block` display not defined in IE 6/7/8/9 and Firefox 3.
- */
-audio,
-canvas,
-video {
-  *display: inline;
-  *zoom: 1;
-}
-/* ==========================================================================
-   Base
-   ========================================================================== */
-/* 
- * Corrects text resizing oddly in IE 6/7 when body `font-size` is set using
- * `em` units.
-*/
-html {
-  font-size: 100%;
-}
-/*
- * Addresses `font-family` inconsistency between `textarea` and other form
- * elements.
- */
-html,
-button,
-input,
-select,
-textarea {
-  font-family: sans-serif;
-}
-/* ==========================================================================
-   Typography
-   ========================================================================== */
-/*
- * Addresses font sizes and margins set differently in IE 6/7.
- * Addresses font sizes within `section` and `article` in Firefox 4+, Safari 5,
- * and Chrome.
- */
-h1 {
-  margin: 0.67em 0;
-}
-h2 {
-  font-size: 1.5em;
-  margin: 0.83em 0;
-}
-h3 {
-  font-size: 1.17em;
-  margin: 1em 0;
-}
-h4 {
-  font-size: 1em;
-  margin: 1.33em 0;
-}
-h5 {
-  font-size: 0.83em;
-  margin: 1.67em 0;
-}
-h6 {
-  font-size: 0.75em;
-  margin: 2.33em 0;
-}
-blockquote {
-  margin: 1em 40px;
-}
-/*
- * Addresses margins set differently in IE 6/7.
- */
-p,
-pre {
-  margin: 1em 0;
-}
-/*
- * Corrects font family set oddly in IE 6, Safari 4/5, and Chrome.
- */
-code,
-kbd,
-pre,
-samp {
-  _font-family: 'courier new', monospace;
-}
-/**
- * Improve readability of pre-formatted text in all browsers.
- */
-pre {
-  white-space: pre;
-  word-wrap: break-word;
-}
-/*
- * Addresses CSS quotes not supported in IE 6/7.
- */
-q {
-  quotes: none;
-}
-/*
- * Addresses `quotes` property not supported in Safari 4.
- */
-q:before,
-q:after {
-  content: '';
-  content: none;
-}
-/* ==========================================================================
-   Lists
-   ========================================================================== */
-/*
- * Addresses margins set differently in IE 6/7.
- */
-dl,
-menu,
-ol,
-ul {
-  margin: 1em 0;
-}
-dd {
-  margin: 0 0 0 40px;
-}
-/*
- * Addresses paddings set differently in IE 6/7.
- */
-menu,
-ol,
-ul {
-  padding: 0 0 0 40px;
-}
-/*
- * Corrects list images handled incorrectly in IE 7.
- */
-nav ul,
-nav ol {
-  list-style: none;
-  list-style-image: none;
-}
-/* ==========================================================================
-   Embedded content
-   ========================================================================== */
-/*
- * Improves image quality when scaled in IE 7.
- */
-img {
-  -ms-interpolation-mode: bicubic;
-}
-/* ==========================================================================
-   Forms
-   ========================================================================== */
-/*
- * Corrects margin displayed oddly in IE 6/7.
- */
-form {
-  margin: 0;
-}
-/*
- * 1. Corrects color not being inherited in IE 6/7/8/9.
- * 2. Corrects text not wrapping in Firefox 3.
- * 3. Corrects alignment displayed oddly in IE 6/7.
- */
-legend {
-  border: 0;
-  /* 1 */
-  white-space: normal;
-  /* 2 */
-  *margin-left: -7px;
-  /* 3 */
-}
-/*
- * Improves appearance and consistency in all browsers.
- */
-button,
-input,
-select,
-textarea {
-  vertical-align: baseline;
-  *vertical-align: middle;
-}
-/*
- * Removes inner spacing in IE 7 without affecting normal text inputs.
- * Known issue: inner spacing remains in IE 6.
- */
-button,
-html input[type="button"],
-input[type="reset"],
-input[type="submit"] {
-  *overflow: visible;
-}
-/*
- * Removes excess padding in IE 7.
- * Known issue: excess padding remains in IE 6.
- */
-input[type="checkbox"],
-input[type="radio"] {
-  *height: 13px;
-  *width: 13px;
-}
-
 /* ==========================================================================
    Setting up cf-grids
    ========================================================================== */
@@ -588,7 +32,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-12:before,
 .col-12:after {
@@ -634,7 +78,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-11:before,
 .col-11:after {
@@ -673,7 +117,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-11.prefix-1 {
   padding-left: 0;
@@ -715,7 +159,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-11.suffix-1 {
   padding-right: 0;
@@ -764,7 +208,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-10:before,
 .col-10:after {
@@ -803,7 +247,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-10.prefix-2 {
   padding-left: 0;
@@ -845,7 +289,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-10.prefix-1 {
   padding-left: 0;
@@ -888,7 +332,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-10.prefix-1.suffix-1 {
   padding-right: 0;
@@ -931,7 +375,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-10.suffix-2 {
   padding-right: 0;
@@ -973,7 +417,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-10.suffix-1 {
   padding-right: 0;
@@ -1022,7 +466,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-9:before,
 .col-9:after {
@@ -1061,7 +505,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-3 {
   padding-left: 0;
@@ -1103,7 +547,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-2 {
   padding-left: 0;
@@ -1146,7 +590,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-2.suffix-1 {
   padding-right: 0;
@@ -1189,7 +633,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-1 {
   padding-left: 0;
@@ -1232,7 +676,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-1.suffix-2 {
   padding-right: 0;
@@ -1276,7 +720,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-1.suffix-1 {
   padding-right: 0;
@@ -1319,7 +763,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.suffix-3 {
   padding-right: 0;
@@ -1361,7 +805,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.suffix-2 {
   padding-right: 0;
@@ -1403,7 +847,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.suffix-1 {
   padding-right: 0;
@@ -1452,7 +896,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-8:before,
 .col-8:after {
@@ -1491,7 +935,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-4 {
   padding-left: 0;
@@ -1533,7 +977,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-3 {
   padding-left: 0;
@@ -1576,7 +1020,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-3.suffix-1 {
   padding-right: 0;
@@ -1619,7 +1063,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-2 {
   padding-left: 0;
@@ -1662,7 +1106,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-2.suffix-2 {
   padding-right: 0;
@@ -1706,7 +1150,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-2.suffix-1 {
   padding-right: 0;
@@ -1749,7 +1193,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-1 {
   padding-left: 0;
@@ -1792,7 +1236,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-1.suffix-3 {
   padding-right: 0;
@@ -1836,7 +1280,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-1.suffix-2 {
   padding-right: 0;
@@ -1880,7 +1324,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-1.suffix-1 {
   padding-right: 0;
@@ -1923,7 +1367,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.suffix-4 {
   padding-right: 0;
@@ -1965,7 +1409,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.suffix-3 {
   padding-right: 0;
@@ -2007,7 +1451,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.suffix-2 {
   padding-right: 0;
@@ -2049,7 +1493,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.suffix-1 {
   padding-right: 0;
@@ -2098,7 +1542,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-7:before,
 .col-7:after {
@@ -2137,7 +1581,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-5 {
   padding-left: 0;
@@ -2179,7 +1623,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-4 {
   padding-left: 0;
@@ -2222,7 +1666,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-4.suffix-1 {
   padding-right: 0;
@@ -2265,7 +1709,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-3 {
   padding-left: 0;
@@ -2308,7 +1752,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-3.suffix-2 {
   padding-right: 0;
@@ -2352,7 +1796,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-3.suffix-1 {
   padding-right: 0;
@@ -2395,7 +1839,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-2 {
   padding-left: 0;
@@ -2438,7 +1882,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-2.suffix-3 {
   padding-right: 0;
@@ -2482,7 +1926,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-2.suffix-2 {
   padding-right: 0;
@@ -2526,7 +1970,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-2.suffix-1 {
   padding-right: 0;
@@ -2569,7 +2013,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-1 {
   padding-left: 0;
@@ -2612,7 +2056,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-1.suffix-4 {
   padding-right: 0;
@@ -2656,7 +2100,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-1.suffix-3 {
   padding-right: 0;
@@ -2700,7 +2144,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-1.suffix-2 {
   padding-right: 0;
@@ -2744,7 +2188,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-1.suffix-1 {
   padding-right: 0;
@@ -2787,7 +2231,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.suffix-5 {
   padding-right: 0;
@@ -2829,7 +2273,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.suffix-4 {
   padding-right: 0;
@@ -2871,7 +2315,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.suffix-3 {
   padding-right: 0;
@@ -2913,7 +2357,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.suffix-2 {
   padding-right: 0;
@@ -2955,7 +2399,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.suffix-1 {
   padding-right: 0;
@@ -3004,7 +2448,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-6:before,
 .col-6:after {
@@ -3043,7 +2487,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-6 {
   padding-left: 0;
@@ -3085,7 +2529,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-5 {
   padding-left: 0;
@@ -3128,7 +2572,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-5.suffix-1 {
   padding-right: 0;
@@ -3171,7 +2615,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-4 {
   padding-left: 0;
@@ -3214,7 +2658,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-4.suffix-2 {
   padding-right: 0;
@@ -3258,7 +2702,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-4.suffix-1 {
   padding-right: 0;
@@ -3301,7 +2745,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-3 {
   padding-left: 0;
@@ -3344,7 +2788,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-3.suffix-3 {
   padding-right: 0;
@@ -3388,7 +2832,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-3.suffix-2 {
   padding-right: 0;
@@ -3432,7 +2876,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-3.suffix-1 {
   padding-right: 0;
@@ -3475,7 +2919,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-2 {
   padding-left: 0;
@@ -3518,7 +2962,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-2.suffix-4 {
   padding-right: 0;
@@ -3562,7 +3006,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-2.suffix-3 {
   padding-right: 0;
@@ -3606,7 +3050,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-2.suffix-2 {
   padding-right: 0;
@@ -3650,7 +3094,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-2.suffix-1 {
   padding-right: 0;
@@ -3693,7 +3137,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1 {
   padding-left: 0;
@@ -3736,7 +3180,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1.suffix-5 {
   padding-right: 0;
@@ -3780,7 +3224,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1.suffix-4 {
   padding-right: 0;
@@ -3824,7 +3268,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1.suffix-3 {
   padding-right: 0;
@@ -3868,7 +3312,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1.suffix-2 {
   padding-right: 0;
@@ -3912,7 +3356,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1.suffix-1 {
   padding-right: 0;
@@ -3955,7 +3399,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-6 {
   padding-right: 0;
@@ -3997,7 +3441,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-5 {
   padding-right: 0;
@@ -4039,7 +3483,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-4 {
   padding-right: 0;
@@ -4081,7 +3525,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-3 {
   padding-right: 0;
@@ -4123,7 +3567,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-2 {
   padding-right: 0;
@@ -4165,7 +3609,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-1 {
   padding-right: 0;
@@ -4214,7 +3658,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-5:before,
 .col-5:after {
@@ -4253,7 +3697,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-7 {
   padding-left: 0;
@@ -4295,7 +3739,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-6 {
   padding-left: 0;
@@ -4338,7 +3782,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-6.suffix-1 {
   padding-right: 0;
@@ -4381,7 +3825,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-5 {
   padding-left: 0;
@@ -4424,7 +3868,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-5.suffix-2 {
   padding-right: 0;
@@ -4468,7 +3912,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-5.suffix-1 {
   padding-right: 0;
@@ -4511,7 +3955,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-4 {
   padding-left: 0;
@@ -4554,7 +3998,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-4.suffix-3 {
   padding-right: 0;
@@ -4598,7 +4042,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-4.suffix-2 {
   padding-right: 0;
@@ -4642,7 +4086,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-4.suffix-1 {
   padding-right: 0;
@@ -4685,7 +4129,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-3 {
   padding-left: 0;
@@ -4728,7 +4172,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-3.suffix-4 {
   padding-right: 0;
@@ -4772,7 +4216,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-3.suffix-3 {
   padding-right: 0;
@@ -4816,7 +4260,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-3.suffix-2 {
   padding-right: 0;
@@ -4860,7 +4304,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-3.suffix-1 {
   padding-right: 0;
@@ -4903,7 +4347,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2 {
   padding-left: 0;
@@ -4946,7 +4390,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2.suffix-5 {
   padding-right: 0;
@@ -4990,7 +4434,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2.suffix-4 {
   padding-right: 0;
@@ -5034,7 +4478,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2.suffix-3 {
   padding-right: 0;
@@ -5078,7 +4522,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2.suffix-2 {
   padding-right: 0;
@@ -5122,7 +4566,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2.suffix-1 {
   padding-right: 0;
@@ -5165,7 +4609,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1 {
   padding-left: 0;
@@ -5208,7 +4652,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-6 {
   padding-right: 0;
@@ -5252,7 +4696,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-5 {
   padding-right: 0;
@@ -5296,7 +4740,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-4 {
   padding-right: 0;
@@ -5340,7 +4784,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-3 {
   padding-right: 0;
@@ -5384,7 +4828,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-2 {
   padding-right: 0;
@@ -5428,7 +4872,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-1 {
   padding-right: 0;
@@ -5471,7 +4915,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-7 {
   padding-right: 0;
@@ -5513,7 +4957,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-6 {
   padding-right: 0;
@@ -5555,7 +4999,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-5 {
   padding-right: 0;
@@ -5597,7 +5041,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-4 {
   padding-right: 0;
@@ -5639,7 +5083,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-3 {
   padding-right: 0;
@@ -5681,7 +5125,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-2 {
   padding-right: 0;
@@ -5723,7 +5167,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-1 {
   padding-right: 0;
@@ -5772,7 +5216,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-4:before,
 .col-4:after {
@@ -5811,7 +5255,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-8 {
   padding-left: 0;
@@ -5853,7 +5297,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-7 {
   padding-left: 0;
@@ -5896,7 +5340,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-7.suffix-1 {
   padding-right: 0;
@@ -5939,7 +5383,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-6 {
   padding-left: 0;
@@ -5982,7 +5426,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-6.suffix-2 {
   padding-right: 0;
@@ -6026,7 +5470,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-6.suffix-1 {
   padding-right: 0;
@@ -6069,7 +5513,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-5 {
   padding-left: 0;
@@ -6112,7 +5556,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-5.suffix-3 {
   padding-right: 0;
@@ -6156,7 +5600,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-5.suffix-2 {
   padding-right: 0;
@@ -6200,7 +5644,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-5.suffix-1 {
   padding-right: 0;
@@ -6243,7 +5687,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-4 {
   padding-left: 0;
@@ -6286,7 +5730,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-4.suffix-4 {
   padding-right: 0;
@@ -6330,7 +5774,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-4.suffix-3 {
   padding-right: 0;
@@ -6374,7 +5818,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-4.suffix-2 {
   padding-right: 0;
@@ -6418,7 +5862,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-4.suffix-1 {
   padding-right: 0;
@@ -6461,7 +5905,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3 {
   padding-left: 0;
@@ -6504,7 +5948,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3.suffix-5 {
   padding-right: 0;
@@ -6548,7 +5992,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3.suffix-4 {
   padding-right: 0;
@@ -6592,7 +6036,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3.suffix-3 {
   padding-right: 0;
@@ -6636,7 +6080,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3.suffix-2 {
   padding-right: 0;
@@ -6680,7 +6124,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3.suffix-1 {
   padding-right: 0;
@@ -6723,7 +6167,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2 {
   padding-left: 0;
@@ -6766,7 +6210,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-6 {
   padding-right: 0;
@@ -6810,7 +6254,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-5 {
   padding-right: 0;
@@ -6854,7 +6298,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-4 {
   padding-right: 0;
@@ -6898,7 +6342,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-3 {
   padding-right: 0;
@@ -6942,7 +6386,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-2 {
   padding-right: 0;
@@ -6986,7 +6430,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-1 {
   padding-right: 0;
@@ -7029,7 +6473,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1 {
   padding-left: 0;
@@ -7072,7 +6516,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-7 {
   padding-right: 0;
@@ -7116,7 +6560,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-6 {
   padding-right: 0;
@@ -7160,7 +6604,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-5 {
   padding-right: 0;
@@ -7204,7 +6648,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-4 {
   padding-right: 0;
@@ -7248,7 +6692,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-3 {
   padding-right: 0;
@@ -7292,7 +6736,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-2 {
   padding-right: 0;
@@ -7336,7 +6780,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-1 {
   padding-right: 0;
@@ -7379,7 +6823,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-8 {
   padding-right: 0;
@@ -7421,7 +6865,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-7 {
   padding-right: 0;
@@ -7463,7 +6907,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-6 {
   padding-right: 0;
@@ -7505,7 +6949,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-5 {
   padding-right: 0;
@@ -7547,7 +6991,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-4 {
   padding-right: 0;
@@ -7589,7 +7033,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-3 {
   padding-right: 0;
@@ -7631,7 +7075,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-2 {
   padding-right: 0;
@@ -7673,7 +7117,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-1 {
   padding-right: 0;
@@ -7722,7 +7166,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-3:before,
 .col-3:after {
@@ -7761,7 +7205,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-9 {
   padding-left: 0;
@@ -7803,7 +7247,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-8 {
   padding-left: 0;
@@ -7846,7 +7290,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-8.suffix-1 {
   padding-right: 0;
@@ -7889,7 +7333,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-7 {
   padding-left: 0;
@@ -7932,7 +7376,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-7.suffix-2 {
   padding-right: 0;
@@ -7976,7 +7420,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-7.suffix-1 {
   padding-right: 0;
@@ -8019,7 +7463,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-6 {
   padding-left: 0;
@@ -8062,7 +7506,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-6.suffix-3 {
   padding-right: 0;
@@ -8106,7 +7550,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-6.suffix-2 {
   padding-right: 0;
@@ -8150,7 +7594,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-6.suffix-1 {
   padding-right: 0;
@@ -8193,7 +7637,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-5 {
   padding-left: 0;
@@ -8236,7 +7680,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-5.suffix-4 {
   padding-right: 0;
@@ -8280,7 +7724,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-5.suffix-3 {
   padding-right: 0;
@@ -8324,7 +7768,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-5.suffix-2 {
   padding-right: 0;
@@ -8368,7 +7812,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-5.suffix-1 {
   padding-right: 0;
@@ -8411,7 +7855,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4 {
   padding-left: 0;
@@ -8454,7 +7898,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4.suffix-5 {
   padding-right: 0;
@@ -8498,7 +7942,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4.suffix-4 {
   padding-right: 0;
@@ -8542,7 +7986,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4.suffix-3 {
   padding-right: 0;
@@ -8586,7 +8030,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4.suffix-2 {
   padding-right: 0;
@@ -8630,7 +8074,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4.suffix-1 {
   padding-right: 0;
@@ -8673,7 +8117,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3 {
   padding-left: 0;
@@ -8716,7 +8160,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-6 {
   padding-right: 0;
@@ -8760,7 +8204,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-5 {
   padding-right: 0;
@@ -8804,7 +8248,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-4 {
   padding-right: 0;
@@ -8848,7 +8292,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-3 {
   padding-right: 0;
@@ -8892,7 +8336,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-2 {
   padding-right: 0;
@@ -8936,7 +8380,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-1 {
   padding-right: 0;
@@ -8979,7 +8423,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2 {
   padding-left: 0;
@@ -9022,7 +8466,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-7 {
   padding-right: 0;
@@ -9066,7 +8510,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-6 {
   padding-right: 0;
@@ -9110,7 +8554,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-5 {
   padding-right: 0;
@@ -9154,7 +8598,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-4 {
   padding-right: 0;
@@ -9198,7 +8642,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-3 {
   padding-right: 0;
@@ -9242,7 +8686,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-2 {
   padding-right: 0;
@@ -9286,7 +8730,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-1 {
   padding-right: 0;
@@ -9329,7 +8773,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1 {
   padding-left: 0;
@@ -9372,7 +8816,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-8 {
   padding-right: 0;
@@ -9416,7 +8860,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-7 {
   padding-right: 0;
@@ -9460,7 +8904,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-6 {
   padding-right: 0;
@@ -9504,7 +8948,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-5 {
   padding-right: 0;
@@ -9548,7 +8992,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-4 {
   padding-right: 0;
@@ -9592,7 +9036,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-3 {
   padding-right: 0;
@@ -9636,7 +9080,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-2 {
   padding-right: 0;
@@ -9680,7 +9124,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-1 {
   padding-right: 0;
@@ -9723,7 +9167,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-9 {
   padding-right: 0;
@@ -9765,7 +9209,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-8 {
   padding-right: 0;
@@ -9807,7 +9251,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-7 {
   padding-right: 0;
@@ -9849,7 +9293,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-6 {
   padding-right: 0;
@@ -9891,7 +9335,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-5 {
   padding-right: 0;
@@ -9933,7 +9377,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-4 {
   padding-right: 0;
@@ -9975,7 +9419,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-3 {
   padding-right: 0;
@@ -10017,7 +9461,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-2 {
   padding-right: 0;
@@ -10059,7 +9503,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-1 {
   padding-right: 0;
@@ -10108,7 +9552,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-2:before,
 .col-2:after {
@@ -10147,7 +9591,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-10 {
   padding-left: 0;
@@ -10189,7 +9633,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-9 {
   padding-left: 0;
@@ -10232,7 +9676,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-9.suffix-1 {
   padding-right: 0;
@@ -10275,7 +9719,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-8 {
   padding-left: 0;
@@ -10318,7 +9762,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-8.suffix-2 {
   padding-right: 0;
@@ -10362,7 +9806,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-8.suffix-1 {
   padding-right: 0;
@@ -10405,7 +9849,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-7 {
   padding-left: 0;
@@ -10448,7 +9892,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-7.suffix-3 {
   padding-right: 0;
@@ -10492,7 +9936,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-7.suffix-2 {
   padding-right: 0;
@@ -10536,7 +9980,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-7.suffix-1 {
   padding-right: 0;
@@ -10579,7 +10023,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-6 {
   padding-left: 0;
@@ -10622,7 +10066,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-6.suffix-4 {
   padding-right: 0;
@@ -10666,7 +10110,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-6.suffix-3 {
   padding-right: 0;
@@ -10710,7 +10154,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-6.suffix-2 {
   padding-right: 0;
@@ -10754,7 +10198,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-6.suffix-1 {
   padding-right: 0;
@@ -10797,7 +10241,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5 {
   padding-left: 0;
@@ -10840,7 +10284,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5.suffix-5 {
   padding-right: 0;
@@ -10884,7 +10328,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5.suffix-4 {
   padding-right: 0;
@@ -10928,7 +10372,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5.suffix-3 {
   padding-right: 0;
@@ -10972,7 +10416,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5.suffix-2 {
   padding-right: 0;
@@ -11016,7 +10460,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5.suffix-1 {
   padding-right: 0;
@@ -11059,7 +10503,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4 {
   padding-left: 0;
@@ -11102,7 +10546,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-6 {
   padding-right: 0;
@@ -11146,7 +10590,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-5 {
   padding-right: 0;
@@ -11190,7 +10634,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-4 {
   padding-right: 0;
@@ -11234,7 +10678,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-3 {
   padding-right: 0;
@@ -11278,7 +10722,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-2 {
   padding-right: 0;
@@ -11322,7 +10766,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-1 {
   padding-right: 0;
@@ -11365,7 +10809,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3 {
   padding-left: 0;
@@ -11408,7 +10852,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-7 {
   padding-right: 0;
@@ -11452,7 +10896,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-6 {
   padding-right: 0;
@@ -11496,7 +10940,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-5 {
   padding-right: 0;
@@ -11540,7 +10984,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-4 {
   padding-right: 0;
@@ -11584,7 +11028,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-3 {
   padding-right: 0;
@@ -11628,7 +11072,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-2 {
   padding-right: 0;
@@ -11672,7 +11116,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-1 {
   padding-right: 0;
@@ -11715,7 +11159,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2 {
   padding-left: 0;
@@ -11758,7 +11202,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-8 {
   padding-right: 0;
@@ -11802,7 +11246,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-7 {
   padding-right: 0;
@@ -11846,7 +11290,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-6 {
   padding-right: 0;
@@ -11890,7 +11334,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-5 {
   padding-right: 0;
@@ -11934,7 +11378,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-4 {
   padding-right: 0;
@@ -11978,7 +11422,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-3 {
   padding-right: 0;
@@ -12022,7 +11466,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-2 {
   padding-right: 0;
@@ -12066,7 +11510,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-1 {
   padding-right: 0;
@@ -12109,7 +11553,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1 {
   padding-left: 0;
@@ -12152,7 +11596,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-9 {
   padding-right: 0;
@@ -12196,7 +11640,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-8 {
   padding-right: 0;
@@ -12240,7 +11684,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-7 {
   padding-right: 0;
@@ -12284,7 +11728,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-6 {
   padding-right: 0;
@@ -12328,7 +11772,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-5 {
   padding-right: 0;
@@ -12372,7 +11816,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-4 {
   padding-right: 0;
@@ -12416,7 +11860,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-3 {
   padding-right: 0;
@@ -12460,7 +11904,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-2 {
   padding-right: 0;
@@ -12504,7 +11948,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-1 {
   padding-right: 0;
@@ -12547,7 +11991,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-10 {
   padding-right: 0;
@@ -12589,7 +12033,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-9 {
   padding-right: 0;
@@ -12631,7 +12075,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-8 {
   padding-right: 0;
@@ -12673,7 +12117,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-7 {
   padding-right: 0;
@@ -12715,7 +12159,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-6 {
   padding-right: 0;
@@ -12757,7 +12201,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-5 {
   padding-right: 0;
@@ -12799,7 +12243,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-4 {
   padding-right: 0;
@@ -12841,7 +12285,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-3 {
   padding-right: 0;
@@ -12883,7 +12327,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-2 {
   padding-right: 0;
@@ -12925,7 +12369,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-1 {
   padding-right: 0;
@@ -12974,7 +12418,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-1:before,
 .col-1:after {
@@ -13013,7 +12457,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-11 {
   padding-left: 0;
@@ -13055,7 +12499,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-10 {
   padding-left: 0;
@@ -13098,7 +12542,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-10.suffix-1 {
   padding-right: 0;
@@ -13141,7 +12585,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-9 {
   padding-left: 0;
@@ -13184,7 +12628,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-9.suffix-2 {
   padding-right: 0;
@@ -13228,7 +12672,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-9.suffix-1 {
   padding-right: 0;
@@ -13271,7 +12715,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-8 {
   padding-left: 0;
@@ -13314,7 +12758,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-8.suffix-3 {
   padding-right: 0;
@@ -13358,7 +12802,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-8.suffix-2 {
   padding-right: 0;
@@ -13402,7 +12846,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-8.suffix-1 {
   padding-right: 0;
@@ -13445,7 +12889,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-7 {
   padding-left: 0;
@@ -13488,7 +12932,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-7.suffix-4 {
   padding-right: 0;
@@ -13532,7 +12976,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-7.suffix-3 {
   padding-right: 0;
@@ -13576,7 +13020,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-7.suffix-2 {
   padding-right: 0;
@@ -13620,7 +13064,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-7.suffix-1 {
   padding-right: 0;
@@ -13663,7 +13107,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6 {
   padding-left: 0;
@@ -13706,7 +13150,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6.suffix-5 {
   padding-right: 0;
@@ -13750,7 +13194,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6.suffix-4 {
   padding-right: 0;
@@ -13794,7 +13238,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6.suffix-3 {
   padding-right: 0;
@@ -13838,7 +13282,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6.suffix-2 {
   padding-right: 0;
@@ -13882,7 +13326,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6.suffix-1 {
   padding-right: 0;
@@ -13925,7 +13369,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5 {
   padding-left: 0;
@@ -13968,7 +13412,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-6 {
   padding-right: 0;
@@ -14012,7 +13456,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-5 {
   padding-right: 0;
@@ -14056,7 +13500,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-4 {
   padding-right: 0;
@@ -14100,7 +13544,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-3 {
   padding-right: 0;
@@ -14144,7 +13588,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-2 {
   padding-right: 0;
@@ -14188,7 +13632,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-1 {
   padding-right: 0;
@@ -14231,7 +13675,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4 {
   padding-left: 0;
@@ -14274,7 +13718,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-7 {
   padding-right: 0;
@@ -14318,7 +13762,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-6 {
   padding-right: 0;
@@ -14362,7 +13806,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-5 {
   padding-right: 0;
@@ -14406,7 +13850,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-4 {
   padding-right: 0;
@@ -14450,7 +13894,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-3 {
   padding-right: 0;
@@ -14494,7 +13938,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-2 {
   padding-right: 0;
@@ -14538,7 +13982,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-1 {
   padding-right: 0;
@@ -14581,7 +14025,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3 {
   padding-left: 0;
@@ -14624,7 +14068,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-8 {
   padding-right: 0;
@@ -14668,7 +14112,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-7 {
   padding-right: 0;
@@ -14712,7 +14156,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-6 {
   padding-right: 0;
@@ -14756,7 +14200,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-5 {
   padding-right: 0;
@@ -14800,7 +14244,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-4 {
   padding-right: 0;
@@ -14844,7 +14288,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-3 {
   padding-right: 0;
@@ -14888,7 +14332,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-2 {
   padding-right: 0;
@@ -14932,7 +14376,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-1 {
   padding-right: 0;
@@ -14975,7 +14419,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2 {
   padding-left: 0;
@@ -15018,7 +14462,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-9 {
   padding-right: 0;
@@ -15062,7 +14506,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-8 {
   padding-right: 0;
@@ -15106,7 +14550,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-7 {
   padding-right: 0;
@@ -15150,7 +14594,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-6 {
   padding-right: 0;
@@ -15194,7 +14638,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-5 {
   padding-right: 0;
@@ -15238,7 +14682,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-4 {
   padding-right: 0;
@@ -15282,7 +14726,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-3 {
   padding-right: 0;
@@ -15326,7 +14770,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-2 {
   padding-right: 0;
@@ -15370,7 +14814,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-1 {
   padding-right: 0;
@@ -15413,7 +14857,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1 {
   padding-left: 0;
@@ -15456,7 +14900,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-10 {
   padding-right: 0;
@@ -15500,7 +14944,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-9 {
   padding-right: 0;
@@ -15544,7 +14988,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-8 {
   padding-right: 0;
@@ -15588,7 +15032,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-7 {
   padding-right: 0;
@@ -15632,7 +15076,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-6 {
   padding-right: 0;
@@ -15676,7 +15120,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-5 {
   padding-right: 0;
@@ -15720,7 +15164,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-4 {
   padding-right: 0;
@@ -15764,7 +15208,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-3 {
   padding-right: 0;
@@ -15808,7 +15252,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-2 {
   padding-right: 0;
@@ -15852,7 +15296,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-1 {
   padding-right: 0;
@@ -15895,7 +15339,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-11 {
   padding-right: 0;
@@ -15937,7 +15381,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-10 {
   padding-right: 0;
@@ -15979,7 +15423,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-9 {
   padding-right: 0;
@@ -16021,7 +15465,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-8 {
   padding-right: 0;
@@ -16063,7 +15507,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-7 {
   padding-right: 0;
@@ -16105,7 +15549,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-6 {
   padding-right: 0;
@@ -16147,7 +15591,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-5 {
   padding-right: 0;
@@ -16189,7 +15633,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-4 {
   padding-right: 0;
@@ -16231,7 +15675,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-3 {
   padding-right: 0;
@@ -16273,7 +15717,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-2 {
   padding-right: 0;
@@ -16315,7 +15759,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-1 {
   padding-right: 0;

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
               <footer class="docs-pattern_footer">
                 <ul class="docs-codenotes">
                   <li>
-                    <pre class="docs-code"><code>@grid_box-sizing-polyfill-path: '/cf-grid/custom-demo/static/css';</code></pre>
+                    <pre class="docs-code"><code>@grid_box-sizing-polyfill-path: '../../box-sizing-polyfill;</code></pre>
                   </li>
                 </ul>
                 <ul class="docs-notes">

--- a/docs/static/css/main.css
+++ b/docs/static/css/main.css
@@ -1,8 +1,12 @@
-/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+/* ==========================================================================
+   Capital Framework
+   Grid mixins
+   ========================================================================== */
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
 /**
  * 1. Set default font family to sans-serif.
- * 2. Prevent iOS text size adjust after orientation change, without disabling
- *    user zoom.
+ * 2. Prevent iOS and IE text size adjust after device orientation change,
+ *    without disabling user zoom.
  */
 html {
   font-family: sans-serif;
@@ -64,7 +68,7 @@ audio:not([controls]) {
 }
 /**
  * Address `[hidden]` styling not present in IE 8/9/10.
- * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
  */
 [hidden],
 template {
@@ -79,7 +83,8 @@ a {
   background-color: transparent;
 }
 /**
- * Improve readability when focused and also mouse hovered in all browsers.
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
  */
 a:active,
 a:hover {
@@ -169,7 +174,6 @@ figure {
  * Address differences between Firefox and other browsers.
  */
 hr {
-  -moz-box-sizing: content-box;
   box-sizing: content-box;
   height: 0;
 }
@@ -292,16 +296,13 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 /**
  * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
- * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
- *    (include `-moz` to future-proof).
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
  */
 input[type="search"] {
   -webkit-appearance: textfield;
   /* 1 */
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box;
-  /* 2 */
   box-sizing: content-box;
+  /* 2 */
 }
 /**
  * Remove inner padding and search cancel button in Safari and Chrome on OS X.
@@ -356,7 +357,6 @@ td,
 th {
   padding: 0;
 }
-
 /*! normalize-legacy-addon | MIT License | https://github.com/cfpb/normalize-legacy-addon */
 /* ==========================================================================
    HTML5 display definitions
@@ -553,11 +553,6 @@ input[type="radio"] {
   *height: 13px;
   *width: 13px;
 }
-
-/* ==========================================================================
-   Capital Framework
-   Grid mixins
-   ========================================================================== */
 /* topdoc
   name: Less variables
   notes:
@@ -568,7 +563,7 @@ input[type="radio"] {
   family: cf-grid
   patterns:
     - codenotes:
-        - "@grid_box-sizing-polyfill-path: '/cf-grid/custom-demo/static/css';"
+        - "@grid_box-sizing-polyfill-path: '../../box-sizing-polyfill;"
       notes:
         - "The path where boxsizing.htc is located."
         - "This path MUST be overridden in your project and set to a root relative url."
@@ -739,3 +734,4 @@ input[type="radio"] {
   name: EOF
   eof: true
 */
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1jc3Mvbm9ybWFsaXplLmNzcyIsIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1sZWdhY3ktYWRkb24vbm9ybWFsaXplLWxlZ2FjeS1hZGRvbi5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7OztBQVFBO0VBQ0UsdUJBQUE7O0VBQ0EsMEJBQUE7O0VBQ0EsOEJBQUE7Ozs7OztBQU9GO0VBQ0UsU0FBQTs7Ozs7Ozs7OztBQWFGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsY0FBQTs7Ozs7O0FBUUY7QUFDQTtBQUNBO0FBQ0E7RUFDRSxxQkFBQTs7RUFDQSx3QkFBQTs7Ozs7OztBQVFGLEtBQUssSUFBSTtFQUNQLGFBQUE7RUFDQSxTQUFBOzs7Ozs7QUFRRjtBQUNBO0VBQ0UsYUFBQTs7Ozs7OztBQVVGO0VBQ0UsNkJBQUE7Ozs7OztBQVFGLENBQUM7QUFDRCxDQUFDO0VBQ0MsVUFBQTs7Ozs7OztBQVVGLElBQUk7RUFDRix5QkFBQTs7Ozs7QUFPRjtBQUNBO0VBQ0UsaUJBQUE7Ozs7O0FBT0Y7RUFDRSxrQkFBQTs7Ozs7O0FBUUY7RUFDRSxjQUFBO0VBQ0EsZ0JBQUE7Ozs7O0FBT0Y7RUFDRSxnQkFBQTtFQUNBLFdBQUE7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7OztBQU9GO0FBQ0E7RUFDRSxjQUFBO0VBQ0EsY0FBQTtFQUNBLGtCQUFBO0VBQ0Esd0JBQUE7O0FBR0Y7RUFDRSxXQUFBOztBQUdGO0VBQ0UsZUFBQTs7Ozs7OztBQVVGO0VBQ0UsU0FBQTs7Ozs7QUFPRixHQUFHLElBQUk7RUFDTCxnQkFBQTs7Ozs7OztBQVVGO0VBQ0UsZ0JBQUE7Ozs7O0FBT0Y7RUFDRSx1QkFBQTtFQUNBLFNBQUE7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7OztBQU9GO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsaUNBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7OztBQWtCRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsY0FBQTs7RUFDQSxhQUFBOztFQUNBLFNBQUE7Ozs7OztBQU9GO0VBQ0UsaUJBQUE7Ozs7Ozs7O0FBVUY7QUFDQTtFQUNFLG9CQUFBOzs7Ozs7Ozs7QUFXRjtBQUNBLElBQUssTUFBSztBQUNWLEtBQUs7QUFDTCxLQUFLO0VBQ0gsMEJBQUE7O0VBQ0EsZUFBQTs7Ozs7O0FBT0YsTUFBTTtBQUNOLElBQUssTUFBSztFQUNSLGVBQUE7Ozs7O0FBT0YsTUFBTTtBQUNOLEtBQUs7RUFDSCxTQUFBO0VBQ0EsVUFBQTs7Ozs7O0FBUUY7RUFDRSxtQkFBQTs7Ozs7Ozs7O0FBV0YsS0FBSztBQUNMLEtBQUs7RUFDSCxzQkFBQTs7RUFDQSxVQUFBOzs7Ozs7OztBQVNGLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7RUFDbEIsWUFBQTs7Ozs7O0FBUUYsS0FBSztFQUNILDZCQUFBOztFQUNBLHVCQUFBOzs7Ozs7OztBQVNGLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7RUFDbEIsd0JBQUE7Ozs7O0FBT0Y7RUFDRSx5QkFBQTtFQUNBLGFBQUE7RUFDQSw4QkFBQTs7Ozs7O0FBUUY7RUFDRSxTQUFBOztFQUNBLFVBQUE7Ozs7OztBQU9GO0VBQ0UsY0FBQTs7Ozs7O0FBUUY7RUFDRSxpQkFBQTs7Ozs7OztBQVVGO0VBQ0UseUJBQUE7RUFDQSxpQkFBQTs7QUFHRjtBQUNBO0VBQ0UsVUFBQTs7Ozs7Ozs7O0FDNVpGO0FBQ0E7QUFDQTtFQUNJLGdCQUFBO0VBQ0EsUUFBQTs7Ozs7Ozs7O0FBWUo7RUFDSSxlQUFBOzs7Ozs7QUFRSjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksdUJBQUE7Ozs7Ozs7Ozs7QUFhSjtFQUNJLGdCQUFBOztBQUdKO0VBQ0ksZ0JBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsYUFBQTs7QUFHSjtFQUNJLGNBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksZ0JBQUE7Ozs7O0FBT0o7QUFDQTtFQUNJLGFBQUE7Ozs7O0FBT0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSxjQUFjLHdCQUFkOzs7OztBQU9KO0VBQ0ksZ0JBQUE7RUFDQSxxQkFBQTs7Ozs7QUFPSjtFQUNJLFlBQUE7Ozs7O0FBT0osQ0FBQztBQUNELENBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxhQUFBOzs7Ozs7OztBQVdKO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtFQUNJLGtCQUFBOzs7OztBQU9KO0FBQ0E7QUFDQTtFQUNJLG1CQUFBOzs7OztBQU9KLEdBQUk7QUFDSixHQUFJO0VBQ0EsZ0JBQUE7RUFDQSxzQkFBQTs7Ozs7Ozs7QUFXSjtFQUNJLCtCQUFBOzs7Ozs7OztBQVdKO0VBQ0ksU0FBQTs7Ozs7OztBQVNKO0VBQ0ksU0FBQTs7RUFDQSxtQkFBQTs7RUFDQSxrQkFBQTs7Ozs7O0FBT0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSx3QkFBQTtFQUNBLHVCQUFBOzs7Ozs7QUFRSjtBQUNBLElBQUssTUFBSztBQUNWLEtBQUs7QUFDTCxLQUFLO0VBQ0Qsa0JBQUE7Ozs7OztBQVFKLEtBQUs7QUFDTCxLQUFLO0VBQ0QsYUFBQTtFQUNBLFlBQUEifQ== */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.9.1",
-    "cf-grunt-config": "~0.3.1",
+    "cf-grunt-config": "cfpb/cf-grunt-config#dev",
     "glob": "~4.3.2",
     "grunt": "~0.4.4",
     "jit-grunt": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "posttest": "forever stopall -s"
   },
   "devDependencies": {
-    "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git#0.9.1",
+    "cf-component-demo": "^1.0.0",
     "cf-grunt-config": "^1.0.0",
     "forever": "^0.14.1",
     "glob": "~4.3.2",

--- a/src-generated/cf-grid-generated.css
+++ b/src-generated/cf-grid-generated.css
@@ -1,559 +1,3 @@
-/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
-/**
- * 1. Set default font family to sans-serif.
- * 2. Prevent iOS text size adjust after orientation change, without disabling
- *    user zoom.
- */
-html {
-  font-family: sans-serif;
-  /* 1 */
-  -ms-text-size-adjust: 100%;
-  /* 2 */
-  -webkit-text-size-adjust: 100%;
-  /* 2 */
-}
-/**
- * Remove default margin.
- */
-body {
-  margin: 0;
-}
-/* HTML5 display definitions
-   ========================================================================== */
-/**
- * Correct `block` display not defined for any HTML5 element in IE 8/9.
- * Correct `block` display not defined for `details` or `summary` in IE 10/11
- * and Firefox.
- * Correct `block` display not defined for `main` in IE 11.
- */
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-main,
-menu,
-nav,
-section,
-summary {
-  display: block;
-}
-/**
- * 1. Correct `inline-block` display not defined in IE 8/9.
- * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
- */
-audio,
-canvas,
-progress,
-video {
-  display: inline-block;
-  /* 1 */
-  vertical-align: baseline;
-  /* 2 */
-}
-/**
- * Prevent modern browsers from displaying `audio` without controls.
- * Remove excess height in iOS 5 devices.
- */
-audio:not([controls]) {
-  display: none;
-  height: 0;
-}
-/**
- * Address `[hidden]` styling not present in IE 8/9/10.
- * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
- */
-[hidden],
-template {
-  display: none;
-}
-/* Links
-   ========================================================================== */
-/**
- * Remove the gray background color from active links in IE 10.
- */
-a {
-  background-color: transparent;
-}
-/**
- * Improve readability when focused and also mouse hovered in all browsers.
- */
-a:active,
-a:hover {
-  outline: 0;
-}
-/* Text-level semantics
-   ========================================================================== */
-/**
- * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
- */
-abbr[title] {
-  border-bottom: 1px dotted;
-}
-/**
- * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
- */
-b,
-strong {
-  font-weight: bold;
-}
-/**
- * Address styling not present in Safari and Chrome.
- */
-dfn {
-  font-style: italic;
-}
-/**
- * Address variable `h1` font-size and margin within `section` and `article`
- * contexts in Firefox 4+, Safari, and Chrome.
- */
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
-}
-/**
- * Address styling not present in IE 8/9.
- */
-mark {
-  background: #ff0;
-  color: #000;
-}
-/**
- * Address inconsistent and variable font size in all browsers.
- */
-small {
-  font-size: 80%;
-}
-/**
- * Prevent `sub` and `sup` affecting `line-height` in all browsers.
- */
-sub,
-sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
-sup {
-  top: -0.5em;
-}
-sub {
-  bottom: -0.25em;
-}
-/* Embedded content
-   ========================================================================== */
-/**
- * Remove border when inside `a` element in IE 8/9/10.
- */
-img {
-  border: 0;
-}
-/**
- * Correct overflow not hidden in IE 9/10/11.
- */
-svg:not(:root) {
-  overflow: hidden;
-}
-/* Grouping content
-   ========================================================================== */
-/**
- * Address margin not present in IE 8/9 and Safari.
- */
-figure {
-  margin: 1em 40px;
-}
-/**
- * Address differences between Firefox and other browsers.
- */
-hr {
-  -moz-box-sizing: content-box;
-  box-sizing: content-box;
-  height: 0;
-}
-/**
- * Contain overflow in all browsers.
- */
-pre {
-  overflow: auto;
-}
-/**
- * Address odd `em`-unit font size rendering in all browsers.
- */
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace, monospace;
-  font-size: 1em;
-}
-/* Forms
-   ========================================================================== */
-/**
- * Known limitation: by default, Chrome and Safari on OS X allow very limited
- * styling of `select`, unless a `border` property is set.
- */
-/**
- * 1. Correct color not being inherited.
- *    Known issue: affects color of disabled elements.
- * 2. Correct font properties not being inherited.
- * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
- */
-button,
-input,
-optgroup,
-select,
-textarea {
-  color: inherit;
-  /* 1 */
-  font: inherit;
-  /* 2 */
-  margin: 0;
-  /* 3 */
-}
-/**
- * Address `overflow` set to `hidden` in IE 8/9/10/11.
- */
-button {
-  overflow: visible;
-}
-/**
- * Address inconsistent `text-transform` inheritance for `button` and `select`.
- * All other form control elements do not inherit `text-transform` values.
- * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
- * Correct `select` style inheritance in Firefox.
- */
-button,
-select {
-  text-transform: none;
-}
-/**
- * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
- *    and `video` controls.
- * 2. Correct inability to style clickable `input` types in iOS.
- * 3. Improve usability and consistency of cursor style between image-type
- *    `input` and others.
- */
-button,
-html input[type="button"],
-input[type="reset"],
-input[type="submit"] {
-  -webkit-appearance: button;
-  /* 2 */
-  cursor: pointer;
-  /* 3 */
-}
-/**
- * Re-set default cursor for disabled elements.
- */
-button[disabled],
-html input[disabled] {
-  cursor: default;
-}
-/**
- * Remove inner padding and border in Firefox 4+.
- */
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
-  padding: 0;
-}
-/**
- * Address Firefox 4+ setting `line-height` on `input` using `!important` in
- * the UA stylesheet.
- */
-input {
-  line-height: normal;
-}
-/**
- * It's recommended that you don't attempt to style these elements.
- * Firefox's implementation doesn't respect box-sizing, padding, or width.
- *
- * 1. Address box sizing set to `content-box` in IE 8/9/10.
- * 2. Remove excess padding in IE 8/9/10.
- */
-input[type="checkbox"],
-input[type="radio"] {
-  box-sizing: border-box;
-  /* 1 */
-  padding: 0;
-  /* 2 */
-}
-/**
- * Fix the cursor style for Chrome's increment/decrement buttons. For certain
- * `font-size` values of the `input`, it causes the cursor style of the
- * decrement button to change from `default` to `text`.
- */
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  height: auto;
-}
-/**
- * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
- * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
- *    (include `-moz` to future-proof).
- */
-input[type="search"] {
-  -webkit-appearance: textfield;
-  /* 1 */
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box;
-  /* 2 */
-  box-sizing: content-box;
-}
-/**
- * Remove inner padding and search cancel button in Safari and Chrome on OS X.
- * Safari (but not Chrome) clips the cancel button when the search input has
- * padding (and `textfield` appearance).
- */
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-/**
- * Define consistent border, margin, and padding.
- */
-fieldset {
-  border: 1px solid #c0c0c0;
-  margin: 0 2px;
-  padding: 0.35em 0.625em 0.75em;
-}
-/**
- * 1. Correct `color` not being inherited in IE 8/9/10/11.
- * 2. Remove padding so people aren't caught out if they zero out fieldsets.
- */
-legend {
-  border: 0;
-  /* 1 */
-  padding: 0;
-  /* 2 */
-}
-/**
- * Remove default vertical scrollbar in IE 8/9/10/11.
- */
-textarea {
-  overflow: auto;
-}
-/**
- * Don't inherit the `font-weight` (applied by a rule above).
- * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
- */
-optgroup {
-  font-weight: bold;
-}
-/* Tables
-   ========================================================================== */
-/**
- * Remove most spacing between table cells.
- */
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-td,
-th {
-  padding: 0;
-}
-
-/*! normalize-legacy-addon | MIT License | https://github.com/cfpb/normalize-legacy-addon */
-/* ==========================================================================
-   HTML5 display definitions
-   ========================================================================== */
-/*
- * Corrects `inline-block` display not defined in IE 6/7/8/9 and Firefox 3.
- */
-audio,
-canvas,
-video {
-  *display: inline;
-  *zoom: 1;
-}
-/* ==========================================================================
-   Base
-   ========================================================================== */
-/* 
- * Corrects text resizing oddly in IE 6/7 when body `font-size` is set using
- * `em` units.
-*/
-html {
-  font-size: 100%;
-}
-/*
- * Addresses `font-family` inconsistency between `textarea` and other form
- * elements.
- */
-html,
-button,
-input,
-select,
-textarea {
-  font-family: sans-serif;
-}
-/* ==========================================================================
-   Typography
-   ========================================================================== */
-/*
- * Addresses font sizes and margins set differently in IE 6/7.
- * Addresses font sizes within `section` and `article` in Firefox 4+, Safari 5,
- * and Chrome.
- */
-h1 {
-  margin: 0.67em 0;
-}
-h2 {
-  font-size: 1.5em;
-  margin: 0.83em 0;
-}
-h3 {
-  font-size: 1.17em;
-  margin: 1em 0;
-}
-h4 {
-  font-size: 1em;
-  margin: 1.33em 0;
-}
-h5 {
-  font-size: 0.83em;
-  margin: 1.67em 0;
-}
-h6 {
-  font-size: 0.75em;
-  margin: 2.33em 0;
-}
-blockquote {
-  margin: 1em 40px;
-}
-/*
- * Addresses margins set differently in IE 6/7.
- */
-p,
-pre {
-  margin: 1em 0;
-}
-/*
- * Corrects font family set oddly in IE 6, Safari 4/5, and Chrome.
- */
-code,
-kbd,
-pre,
-samp {
-  _font-family: 'courier new', monospace;
-}
-/**
- * Improve readability of pre-formatted text in all browsers.
- */
-pre {
-  white-space: pre;
-  word-wrap: break-word;
-}
-/*
- * Addresses CSS quotes not supported in IE 6/7.
- */
-q {
-  quotes: none;
-}
-/*
- * Addresses `quotes` property not supported in Safari 4.
- */
-q:before,
-q:after {
-  content: '';
-  content: none;
-}
-/* ==========================================================================
-   Lists
-   ========================================================================== */
-/*
- * Addresses margins set differently in IE 6/7.
- */
-dl,
-menu,
-ol,
-ul {
-  margin: 1em 0;
-}
-dd {
-  margin: 0 0 0 40px;
-}
-/*
- * Addresses paddings set differently in IE 6/7.
- */
-menu,
-ol,
-ul {
-  padding: 0 0 0 40px;
-}
-/*
- * Corrects list images handled incorrectly in IE 7.
- */
-nav ul,
-nav ol {
-  list-style: none;
-  list-style-image: none;
-}
-/* ==========================================================================
-   Embedded content
-   ========================================================================== */
-/*
- * Improves image quality when scaled in IE 7.
- */
-img {
-  -ms-interpolation-mode: bicubic;
-}
-/* ==========================================================================
-   Forms
-   ========================================================================== */
-/*
- * Corrects margin displayed oddly in IE 6/7.
- */
-form {
-  margin: 0;
-}
-/*
- * 1. Corrects color not being inherited in IE 6/7/8/9.
- * 2. Corrects text not wrapping in Firefox 3.
- * 3. Corrects alignment displayed oddly in IE 6/7.
- */
-legend {
-  border: 0;
-  /* 1 */
-  white-space: normal;
-  /* 2 */
-  *margin-left: -7px;
-  /* 3 */
-}
-/*
- * Improves appearance and consistency in all browsers.
- */
-button,
-input,
-select,
-textarea {
-  vertical-align: baseline;
-  *vertical-align: middle;
-}
-/*
- * Removes inner spacing in IE 7 without affecting normal text inputs.
- * Known issue: inner spacing remains in IE 6.
- */
-button,
-html input[type="button"],
-input[type="reset"],
-input[type="submit"] {
-  *overflow: visible;
-}
-/*
- * Removes excess padding in IE 7.
- * Known issue: excess padding remains in IE 6.
- */
-input[type="checkbox"],
-input[type="radio"] {
-  *height: 13px;
-  *width: 13px;
-}
-
 /**
  *  A CSS version of cf-grid
  **/
@@ -579,7 +23,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .push-12 {
   position: relative;
@@ -604,7 +48,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-11.prefix-1 {
   display: inline-block;
@@ -622,7 +66,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-11.prefix-1 {
   padding-left: 0;
@@ -643,7 +87,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-11.suffix-1 {
   padding-right: 0;
@@ -671,7 +115,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-10.prefix-2 {
   display: inline-block;
@@ -689,7 +133,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-10.prefix-2 {
   padding-left: 0;
@@ -710,7 +154,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-10.prefix-1 {
   padding-left: 0;
@@ -732,7 +176,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-10.prefix-1.suffix-1 {
   padding-right: 0;
@@ -754,7 +198,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-10.suffix-2 {
   padding-right: 0;
@@ -775,7 +219,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-10.suffix-1 {
   padding-right: 0;
@@ -803,7 +247,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-9.prefix-3 {
   display: inline-block;
@@ -821,7 +265,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-3 {
   padding-left: 0;
@@ -842,7 +286,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-2 {
   padding-left: 0;
@@ -864,7 +308,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-2.suffix-1 {
   padding-right: 0;
@@ -886,7 +330,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-1 {
   padding-left: 0;
@@ -908,7 +352,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-1.suffix-2 {
   padding-right: 0;
@@ -931,7 +375,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.prefix-1.suffix-1 {
   padding-right: 0;
@@ -953,7 +397,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.suffix-3 {
   padding-right: 0;
@@ -974,7 +418,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.suffix-2 {
   padding-right: 0;
@@ -995,7 +439,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-9.suffix-1 {
   padding-right: 0;
@@ -1023,7 +467,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-8.prefix-4 {
   display: inline-block;
@@ -1041,7 +485,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-4 {
   padding-left: 0;
@@ -1062,7 +506,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-3 {
   padding-left: 0;
@@ -1084,7 +528,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-3.suffix-1 {
   padding-right: 0;
@@ -1106,7 +550,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-2 {
   padding-left: 0;
@@ -1128,7 +572,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-2.suffix-2 {
   padding-right: 0;
@@ -1151,7 +595,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-2.suffix-1 {
   padding-right: 0;
@@ -1173,7 +617,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-1 {
   padding-left: 0;
@@ -1195,7 +639,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-1.suffix-3 {
   padding-right: 0;
@@ -1218,7 +662,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-1.suffix-2 {
   padding-right: 0;
@@ -1241,7 +685,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.prefix-1.suffix-1 {
   padding-right: 0;
@@ -1263,7 +707,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.suffix-4 {
   padding-right: 0;
@@ -1284,7 +728,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.suffix-3 {
   padding-right: 0;
@@ -1305,7 +749,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.suffix-2 {
   padding-right: 0;
@@ -1326,7 +770,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-8.suffix-1 {
   padding-right: 0;
@@ -1354,7 +798,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-7.prefix-5 {
   display: inline-block;
@@ -1372,7 +816,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-5 {
   padding-left: 0;
@@ -1393,7 +837,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-4 {
   padding-left: 0;
@@ -1415,7 +859,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-4.suffix-1 {
   padding-right: 0;
@@ -1437,7 +881,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-3 {
   padding-left: 0;
@@ -1459,7 +903,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-3.suffix-2 {
   padding-right: 0;
@@ -1482,7 +926,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-3.suffix-1 {
   padding-right: 0;
@@ -1504,7 +948,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-2 {
   padding-left: 0;
@@ -1526,7 +970,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-2.suffix-3 {
   padding-right: 0;
@@ -1549,7 +993,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-2.suffix-2 {
   padding-right: 0;
@@ -1572,7 +1016,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-2.suffix-1 {
   padding-right: 0;
@@ -1594,7 +1038,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-1 {
   padding-left: 0;
@@ -1616,7 +1060,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-1.suffix-4 {
   padding-right: 0;
@@ -1639,7 +1083,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-1.suffix-3 {
   padding-right: 0;
@@ -1662,7 +1106,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-1.suffix-2 {
   padding-right: 0;
@@ -1685,7 +1129,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.prefix-1.suffix-1 {
   padding-right: 0;
@@ -1707,7 +1151,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.suffix-5 {
   padding-right: 0;
@@ -1728,7 +1172,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.suffix-4 {
   padding-right: 0;
@@ -1749,7 +1193,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.suffix-3 {
   padding-right: 0;
@@ -1770,7 +1214,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.suffix-2 {
   padding-right: 0;
@@ -1791,7 +1235,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-7.suffix-1 {
   padding-right: 0;
@@ -1819,7 +1263,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-6.prefix-6 {
   display: inline-block;
@@ -1837,7 +1281,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-6 {
   padding-left: 0;
@@ -1858,7 +1302,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-5 {
   padding-left: 0;
@@ -1880,7 +1324,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-5.suffix-1 {
   padding-right: 0;
@@ -1902,7 +1346,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-4 {
   padding-left: 0;
@@ -1924,7 +1368,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-4.suffix-2 {
   padding-right: 0;
@@ -1947,7 +1391,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-4.suffix-1 {
   padding-right: 0;
@@ -1969,7 +1413,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-3 {
   padding-left: 0;
@@ -1991,7 +1435,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-3.suffix-3 {
   padding-right: 0;
@@ -2014,7 +1458,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-3.suffix-2 {
   padding-right: 0;
@@ -2037,7 +1481,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-3.suffix-1 {
   padding-right: 0;
@@ -2059,7 +1503,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-2 {
   padding-left: 0;
@@ -2081,7 +1525,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-2.suffix-4 {
   padding-right: 0;
@@ -2104,7 +1548,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-2.suffix-3 {
   padding-right: 0;
@@ -2127,7 +1571,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-2.suffix-2 {
   padding-right: 0;
@@ -2150,7 +1594,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-2.suffix-1 {
   padding-right: 0;
@@ -2172,7 +1616,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1 {
   padding-left: 0;
@@ -2194,7 +1638,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1.suffix-5 {
   padding-right: 0;
@@ -2217,7 +1661,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1.suffix-4 {
   padding-right: 0;
@@ -2240,7 +1684,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1.suffix-3 {
   padding-right: 0;
@@ -2263,7 +1707,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1.suffix-2 {
   padding-right: 0;
@@ -2286,7 +1730,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.prefix-1.suffix-1 {
   padding-right: 0;
@@ -2308,7 +1752,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-6 {
   padding-right: 0;
@@ -2329,7 +1773,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-5 {
   padding-right: 0;
@@ -2350,7 +1794,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-4 {
   padding-right: 0;
@@ -2371,7 +1815,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-3 {
   padding-right: 0;
@@ -2392,7 +1836,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-2 {
   padding-right: 0;
@@ -2413,7 +1857,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-6.suffix-1 {
   padding-right: 0;
@@ -2441,7 +1885,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-5.prefix-7 {
   display: inline-block;
@@ -2459,7 +1903,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-7 {
   padding-left: 0;
@@ -2480,7 +1924,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-6 {
   padding-left: 0;
@@ -2502,7 +1946,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-6.suffix-1 {
   padding-right: 0;
@@ -2524,7 +1968,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-5 {
   padding-left: 0;
@@ -2546,7 +1990,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-5.suffix-2 {
   padding-right: 0;
@@ -2569,7 +2013,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-5.suffix-1 {
   padding-right: 0;
@@ -2591,7 +2035,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-4 {
   padding-left: 0;
@@ -2613,7 +2057,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-4.suffix-3 {
   padding-right: 0;
@@ -2636,7 +2080,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-4.suffix-2 {
   padding-right: 0;
@@ -2659,7 +2103,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-4.suffix-1 {
   padding-right: 0;
@@ -2681,7 +2125,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-3 {
   padding-left: 0;
@@ -2703,7 +2147,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-3.suffix-4 {
   padding-right: 0;
@@ -2726,7 +2170,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-3.suffix-3 {
   padding-right: 0;
@@ -2749,7 +2193,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-3.suffix-2 {
   padding-right: 0;
@@ -2772,7 +2216,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-3.suffix-1 {
   padding-right: 0;
@@ -2794,7 +2238,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2 {
   padding-left: 0;
@@ -2816,7 +2260,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2.suffix-5 {
   padding-right: 0;
@@ -2839,7 +2283,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2.suffix-4 {
   padding-right: 0;
@@ -2862,7 +2306,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2.suffix-3 {
   padding-right: 0;
@@ -2885,7 +2329,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2.suffix-2 {
   padding-right: 0;
@@ -2908,7 +2352,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-2.suffix-1 {
   padding-right: 0;
@@ -2930,7 +2374,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1 {
   padding-left: 0;
@@ -2952,7 +2396,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-6 {
   padding-right: 0;
@@ -2975,7 +2419,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-5 {
   padding-right: 0;
@@ -2998,7 +2442,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-4 {
   padding-right: 0;
@@ -3021,7 +2465,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-3 {
   padding-right: 0;
@@ -3044,7 +2488,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-2 {
   padding-right: 0;
@@ -3067,7 +2511,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.prefix-1.suffix-1 {
   padding-right: 0;
@@ -3089,7 +2533,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-7 {
   padding-right: 0;
@@ -3110,7 +2554,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-6 {
   padding-right: 0;
@@ -3131,7 +2575,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-5 {
   padding-right: 0;
@@ -3152,7 +2596,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-4 {
   padding-right: 0;
@@ -3173,7 +2617,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-3 {
   padding-right: 0;
@@ -3194,7 +2638,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-2 {
   padding-right: 0;
@@ -3215,7 +2659,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-5.suffix-1 {
   padding-right: 0;
@@ -3243,7 +2687,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-4.prefix-8 {
   display: inline-block;
@@ -3261,7 +2705,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-8 {
   padding-left: 0;
@@ -3282,7 +2726,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-7 {
   padding-left: 0;
@@ -3304,7 +2748,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-7.suffix-1 {
   padding-right: 0;
@@ -3326,7 +2770,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-6 {
   padding-left: 0;
@@ -3348,7 +2792,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-6.suffix-2 {
   padding-right: 0;
@@ -3371,7 +2815,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-6.suffix-1 {
   padding-right: 0;
@@ -3393,7 +2837,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-5 {
   padding-left: 0;
@@ -3415,7 +2859,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-5.suffix-3 {
   padding-right: 0;
@@ -3438,7 +2882,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-5.suffix-2 {
   padding-right: 0;
@@ -3461,7 +2905,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-5.suffix-1 {
   padding-right: 0;
@@ -3483,7 +2927,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-4 {
   padding-left: 0;
@@ -3505,7 +2949,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-4.suffix-4 {
   padding-right: 0;
@@ -3528,7 +2972,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-4.suffix-3 {
   padding-right: 0;
@@ -3551,7 +2995,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-4.suffix-2 {
   padding-right: 0;
@@ -3574,7 +3018,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-4.suffix-1 {
   padding-right: 0;
@@ -3596,7 +3040,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3 {
   padding-left: 0;
@@ -3618,7 +3062,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3.suffix-5 {
   padding-right: 0;
@@ -3641,7 +3085,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3.suffix-4 {
   padding-right: 0;
@@ -3664,7 +3108,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3.suffix-3 {
   padding-right: 0;
@@ -3687,7 +3131,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3.suffix-2 {
   padding-right: 0;
@@ -3710,7 +3154,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-3.suffix-1 {
   padding-right: 0;
@@ -3732,7 +3176,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2 {
   padding-left: 0;
@@ -3754,7 +3198,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-6 {
   padding-right: 0;
@@ -3777,7 +3221,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-5 {
   padding-right: 0;
@@ -3800,7 +3244,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-4 {
   padding-right: 0;
@@ -3823,7 +3267,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-3 {
   padding-right: 0;
@@ -3846,7 +3290,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-2 {
   padding-right: 0;
@@ -3869,7 +3313,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-2.suffix-1 {
   padding-right: 0;
@@ -3891,7 +3335,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1 {
   padding-left: 0;
@@ -3913,7 +3357,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-7 {
   padding-right: 0;
@@ -3936,7 +3380,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-6 {
   padding-right: 0;
@@ -3959,7 +3403,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-5 {
   padding-right: 0;
@@ -3982,7 +3426,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-4 {
   padding-right: 0;
@@ -4005,7 +3449,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-3 {
   padding-right: 0;
@@ -4028,7 +3472,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-2 {
   padding-right: 0;
@@ -4051,7 +3495,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.prefix-1.suffix-1 {
   padding-right: 0;
@@ -4073,7 +3517,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-8 {
   padding-right: 0;
@@ -4094,7 +3538,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-7 {
   padding-right: 0;
@@ -4115,7 +3559,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-6 {
   padding-right: 0;
@@ -4136,7 +3580,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-5 {
   padding-right: 0;
@@ -4157,7 +3601,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-4 {
   padding-right: 0;
@@ -4178,7 +3622,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-3 {
   padding-right: 0;
@@ -4199,7 +3643,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-2 {
   padding-right: 0;
@@ -4220,7 +3664,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-4.suffix-1 {
   padding-right: 0;
@@ -4248,7 +3692,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-3.prefix-9 {
   display: inline-block;
@@ -4266,7 +3710,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-9 {
   padding-left: 0;
@@ -4287,7 +3731,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-8 {
   padding-left: 0;
@@ -4309,7 +3753,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-8.suffix-1 {
   padding-right: 0;
@@ -4331,7 +3775,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-7 {
   padding-left: 0;
@@ -4353,7 +3797,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-7.suffix-2 {
   padding-right: 0;
@@ -4376,7 +3820,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-7.suffix-1 {
   padding-right: 0;
@@ -4398,7 +3842,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-6 {
   padding-left: 0;
@@ -4420,7 +3864,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-6.suffix-3 {
   padding-right: 0;
@@ -4443,7 +3887,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-6.suffix-2 {
   padding-right: 0;
@@ -4466,7 +3910,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-6.suffix-1 {
   padding-right: 0;
@@ -4488,7 +3932,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-5 {
   padding-left: 0;
@@ -4510,7 +3954,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-5.suffix-4 {
   padding-right: 0;
@@ -4533,7 +3977,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-5.suffix-3 {
   padding-right: 0;
@@ -4556,7 +4000,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-5.suffix-2 {
   padding-right: 0;
@@ -4579,7 +4023,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-5.suffix-1 {
   padding-right: 0;
@@ -4601,7 +4045,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4 {
   padding-left: 0;
@@ -4623,7 +4067,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4.suffix-5 {
   padding-right: 0;
@@ -4646,7 +4090,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4.suffix-4 {
   padding-right: 0;
@@ -4669,7 +4113,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4.suffix-3 {
   padding-right: 0;
@@ -4692,7 +4136,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4.suffix-2 {
   padding-right: 0;
@@ -4715,7 +4159,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-4.suffix-1 {
   padding-right: 0;
@@ -4737,7 +4181,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3 {
   padding-left: 0;
@@ -4759,7 +4203,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-6 {
   padding-right: 0;
@@ -4782,7 +4226,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-5 {
   padding-right: 0;
@@ -4805,7 +4249,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-4 {
   padding-right: 0;
@@ -4828,7 +4272,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-3 {
   padding-right: 0;
@@ -4851,7 +4295,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-2 {
   padding-right: 0;
@@ -4874,7 +4318,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-3.suffix-1 {
   padding-right: 0;
@@ -4896,7 +4340,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2 {
   padding-left: 0;
@@ -4918,7 +4362,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-7 {
   padding-right: 0;
@@ -4941,7 +4385,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-6 {
   padding-right: 0;
@@ -4964,7 +4408,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-5 {
   padding-right: 0;
@@ -4987,7 +4431,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-4 {
   padding-right: 0;
@@ -5010,7 +4454,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-3 {
   padding-right: 0;
@@ -5033,7 +4477,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-2 {
   padding-right: 0;
@@ -5056,7 +4500,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-2.suffix-1 {
   padding-right: 0;
@@ -5078,7 +4522,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1 {
   padding-left: 0;
@@ -5100,7 +4544,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-8 {
   padding-right: 0;
@@ -5123,7 +4567,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-7 {
   padding-right: 0;
@@ -5146,7 +4590,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-6 {
   padding-right: 0;
@@ -5169,7 +4613,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-5 {
   padding-right: 0;
@@ -5192,7 +4636,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-4 {
   padding-right: 0;
@@ -5215,7 +4659,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-3 {
   padding-right: 0;
@@ -5238,7 +4682,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-2 {
   padding-right: 0;
@@ -5261,7 +4705,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.prefix-1.suffix-1 {
   padding-right: 0;
@@ -5283,7 +4727,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-9 {
   padding-right: 0;
@@ -5304,7 +4748,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-8 {
   padding-right: 0;
@@ -5325,7 +4769,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-7 {
   padding-right: 0;
@@ -5346,7 +4790,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-6 {
   padding-right: 0;
@@ -5367,7 +4811,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-5 {
   padding-right: 0;
@@ -5388,7 +4832,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-4 {
   padding-right: 0;
@@ -5409,7 +4853,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-3 {
   padding-right: 0;
@@ -5430,7 +4874,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-2 {
   padding-right: 0;
@@ -5451,7 +4895,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-3.suffix-1 {
   padding-right: 0;
@@ -5479,7 +4923,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-2.prefix-10 {
   display: inline-block;
@@ -5497,7 +4941,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-10 {
   padding-left: 0;
@@ -5518,7 +4962,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-9 {
   padding-left: 0;
@@ -5540,7 +4984,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-9.suffix-1 {
   padding-right: 0;
@@ -5562,7 +5006,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-8 {
   padding-left: 0;
@@ -5584,7 +5028,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-8.suffix-2 {
   padding-right: 0;
@@ -5607,7 +5051,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-8.suffix-1 {
   padding-right: 0;
@@ -5629,7 +5073,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-7 {
   padding-left: 0;
@@ -5651,7 +5095,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-7.suffix-3 {
   padding-right: 0;
@@ -5674,7 +5118,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-7.suffix-2 {
   padding-right: 0;
@@ -5697,7 +5141,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-7.suffix-1 {
   padding-right: 0;
@@ -5719,7 +5163,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-6 {
   padding-left: 0;
@@ -5741,7 +5185,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-6.suffix-4 {
   padding-right: 0;
@@ -5764,7 +5208,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-6.suffix-3 {
   padding-right: 0;
@@ -5787,7 +5231,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-6.suffix-2 {
   padding-right: 0;
@@ -5810,7 +5254,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-6.suffix-1 {
   padding-right: 0;
@@ -5832,7 +5276,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5 {
   padding-left: 0;
@@ -5854,7 +5298,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5.suffix-5 {
   padding-right: 0;
@@ -5877,7 +5321,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5.suffix-4 {
   padding-right: 0;
@@ -5900,7 +5344,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5.suffix-3 {
   padding-right: 0;
@@ -5923,7 +5367,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5.suffix-2 {
   padding-right: 0;
@@ -5946,7 +5390,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-5.suffix-1 {
   padding-right: 0;
@@ -5968,7 +5412,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4 {
   padding-left: 0;
@@ -5990,7 +5434,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-6 {
   padding-right: 0;
@@ -6013,7 +5457,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-5 {
   padding-right: 0;
@@ -6036,7 +5480,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-4 {
   padding-right: 0;
@@ -6059,7 +5503,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-3 {
   padding-right: 0;
@@ -6082,7 +5526,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-2 {
   padding-right: 0;
@@ -6105,7 +5549,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-4.suffix-1 {
   padding-right: 0;
@@ -6127,7 +5571,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3 {
   padding-left: 0;
@@ -6149,7 +5593,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-7 {
   padding-right: 0;
@@ -6172,7 +5616,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-6 {
   padding-right: 0;
@@ -6195,7 +5639,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-5 {
   padding-right: 0;
@@ -6218,7 +5662,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-4 {
   padding-right: 0;
@@ -6241,7 +5685,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-3 {
   padding-right: 0;
@@ -6264,7 +5708,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-2 {
   padding-right: 0;
@@ -6287,7 +5731,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-3.suffix-1 {
   padding-right: 0;
@@ -6309,7 +5753,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2 {
   padding-left: 0;
@@ -6331,7 +5775,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-8 {
   padding-right: 0;
@@ -6354,7 +5798,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-7 {
   padding-right: 0;
@@ -6377,7 +5821,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-6 {
   padding-right: 0;
@@ -6400,7 +5844,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-5 {
   padding-right: 0;
@@ -6423,7 +5867,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-4 {
   padding-right: 0;
@@ -6446,7 +5890,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-3 {
   padding-right: 0;
@@ -6469,7 +5913,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-2 {
   padding-right: 0;
@@ -6492,7 +5936,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-2.suffix-1 {
   padding-right: 0;
@@ -6514,7 +5958,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1 {
   padding-left: 0;
@@ -6536,7 +5980,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-9 {
   padding-right: 0;
@@ -6559,7 +6003,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-8 {
   padding-right: 0;
@@ -6582,7 +6026,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-7 {
   padding-right: 0;
@@ -6605,7 +6049,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-6 {
   padding-right: 0;
@@ -6628,7 +6072,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-5 {
   padding-right: 0;
@@ -6651,7 +6095,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-4 {
   padding-right: 0;
@@ -6674,7 +6118,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-3 {
   padding-right: 0;
@@ -6697,7 +6141,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-2 {
   padding-right: 0;
@@ -6720,7 +6164,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.prefix-1.suffix-1 {
   padding-right: 0;
@@ -6742,7 +6186,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-10 {
   padding-right: 0;
@@ -6763,7 +6207,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-9 {
   padding-right: 0;
@@ -6784,7 +6228,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-8 {
   padding-right: 0;
@@ -6805,7 +6249,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-7 {
   padding-right: 0;
@@ -6826,7 +6270,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-6 {
   padding-right: 0;
@@ -6847,7 +6291,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-5 {
   padding-right: 0;
@@ -6868,7 +6312,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-4 {
   padding-right: 0;
@@ -6889,7 +6333,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-3 {
   padding-right: 0;
@@ -6910,7 +6354,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-2 {
   padding-right: 0;
@@ -6931,7 +6375,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-2.suffix-1 {
   padding-right: 0;
@@ -6959,7 +6403,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .col-1.prefix-11 {
   display: inline-block;
@@ -6977,7 +6421,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-11 {
   padding-left: 0;
@@ -6998,7 +6442,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-10 {
   padding-left: 0;
@@ -7020,7 +6464,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-10.suffix-1 {
   padding-right: 0;
@@ -7042,7 +6486,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-9 {
   padding-left: 0;
@@ -7064,7 +6508,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-9.suffix-2 {
   padding-right: 0;
@@ -7087,7 +6531,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-9.suffix-1 {
   padding-right: 0;
@@ -7109,7 +6553,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-8 {
   padding-left: 0;
@@ -7131,7 +6575,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-8.suffix-3 {
   padding-right: 0;
@@ -7154,7 +6598,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-8.suffix-2 {
   padding-right: 0;
@@ -7177,7 +6621,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-8.suffix-1 {
   padding-right: 0;
@@ -7199,7 +6643,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-7 {
   padding-left: 0;
@@ -7221,7 +6665,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-7.suffix-4 {
   padding-right: 0;
@@ -7244,7 +6688,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-7.suffix-3 {
   padding-right: 0;
@@ -7267,7 +6711,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-7.suffix-2 {
   padding-right: 0;
@@ -7290,7 +6734,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-7.suffix-1 {
   padding-right: 0;
@@ -7312,7 +6756,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6 {
   padding-left: 0;
@@ -7334,7 +6778,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6.suffix-5 {
   padding-right: 0;
@@ -7357,7 +6801,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6.suffix-4 {
   padding-right: 0;
@@ -7380,7 +6824,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6.suffix-3 {
   padding-right: 0;
@@ -7403,7 +6847,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6.suffix-2 {
   padding-right: 0;
@@ -7426,7 +6870,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-6.suffix-1 {
   padding-right: 0;
@@ -7448,7 +6892,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5 {
   padding-left: 0;
@@ -7470,7 +6914,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-6 {
   padding-right: 0;
@@ -7493,7 +6937,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-5 {
   padding-right: 0;
@@ -7516,7 +6960,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-4 {
   padding-right: 0;
@@ -7539,7 +6983,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-3 {
   padding-right: 0;
@@ -7562,7 +7006,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-2 {
   padding-right: 0;
@@ -7585,7 +7029,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-5.suffix-1 {
   padding-right: 0;
@@ -7607,7 +7051,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4 {
   padding-left: 0;
@@ -7629,7 +7073,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-7 {
   padding-right: 0;
@@ -7652,7 +7096,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-6 {
   padding-right: 0;
@@ -7675,7 +7119,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-5 {
   padding-right: 0;
@@ -7698,7 +7142,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-4 {
   padding-right: 0;
@@ -7721,7 +7165,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-3 {
   padding-right: 0;
@@ -7744,7 +7188,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-2 {
   padding-right: 0;
@@ -7767,7 +7211,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-4.suffix-1 {
   padding-right: 0;
@@ -7789,7 +7233,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3 {
   padding-left: 0;
@@ -7811,7 +7255,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-8 {
   padding-right: 0;
@@ -7834,7 +7278,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-7 {
   padding-right: 0;
@@ -7857,7 +7301,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-6 {
   padding-right: 0;
@@ -7880,7 +7324,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-5 {
   padding-right: 0;
@@ -7903,7 +7347,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-4 {
   padding-right: 0;
@@ -7926,7 +7370,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-3 {
   padding-right: 0;
@@ -7949,7 +7393,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-2 {
   padding-right: 0;
@@ -7972,7 +7416,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-3.suffix-1 {
   padding-right: 0;
@@ -7994,7 +7438,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2 {
   padding-left: 0;
@@ -8016,7 +7460,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-9 {
   padding-right: 0;
@@ -8039,7 +7483,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-8 {
   padding-right: 0;
@@ -8062,7 +7506,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-7 {
   padding-right: 0;
@@ -8085,7 +7529,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-6 {
   padding-right: 0;
@@ -8108,7 +7552,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-5 {
   padding-right: 0;
@@ -8131,7 +7575,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-4 {
   padding-right: 0;
@@ -8154,7 +7598,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-3 {
   padding-right: 0;
@@ -8177,7 +7621,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-2 {
   padding-right: 0;
@@ -8200,7 +7644,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-2.suffix-1 {
   padding-right: 0;
@@ -8222,7 +7666,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1 {
   padding-left: 0;
@@ -8244,7 +7688,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-10 {
   padding-right: 0;
@@ -8267,7 +7711,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-9 {
   padding-right: 0;
@@ -8290,7 +7734,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-8 {
   padding-right: 0;
@@ -8313,7 +7757,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-7 {
   padding-right: 0;
@@ -8336,7 +7780,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-6 {
   padding-right: 0;
@@ -8359,7 +7803,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-5 {
   padding-right: 0;
@@ -8382,7 +7826,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-4 {
   padding-right: 0;
@@ -8405,7 +7849,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-3 {
   padding-right: 0;
@@ -8428,7 +7872,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-2 {
   padding-right: 0;
@@ -8451,7 +7895,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.prefix-1.suffix-1 {
   padding-right: 0;
@@ -8473,7 +7917,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-11 {
   padding-right: 0;
@@ -8494,7 +7938,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-10 {
   padding-right: 0;
@@ -8515,7 +7959,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-9 {
   padding-right: 0;
@@ -8536,7 +7980,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-8 {
   padding-right: 0;
@@ -8557,7 +8001,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-7 {
   padding-right: 0;
@@ -8578,7 +8022,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-6 {
   padding-right: 0;
@@ -8599,7 +8043,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-5 {
   padding-right: 0;
@@ -8620,7 +8064,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-4 {
   padding-right: 0;
@@ -8641,7 +8085,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-3 {
   padding-right: 0;
@@ -8662,7 +8106,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-2 {
   padding-right: 0;
@@ -8683,7 +8127,7 @@ input[type="radio"] {
   display: inline;
   margin-right: 0;
   zoom: 1;
-  behavior: url('/cf-grid/custom-demo/static/css/boxsizing.htc');
+  behavior: url('../../box-sizing-polyfill/boxsizing.htc');
 }
 .lt-ie8 .col-1.suffix-1 {
   padding-right: 0;

--- a/src/cf-grid.less
+++ b/src/cf-grid.less
@@ -3,6 +3,9 @@
    Grid mixins
    ========================================================================== */
 
+@import (less) "../../normalize-css/normalize.css";
+@import (less) "../../normalize-legacy-addon/normalize-legacy-addon.css";
+
 /* topdoc
   name: Less variables
   notes:
@@ -13,7 +16,7 @@
   family: cf-grid
   patterns:
     - codenotes:
-        - "@grid_box-sizing-polyfill-path: '/cf-grid/custom-demo/static/css';"
+        - "@grid_box-sizing-polyfill-path: '../../box-sizing-polyfill;"
       notes:
         - "The path where boxsizing.htc is located."
         - "This path MUST be overridden in your project and set to a root relative url."
@@ -37,7 +40,7 @@
     - cf-grid
 */
 
-@grid_box-sizing-polyfill-path: '/cf-grid/custom-demo/static/css';
+@grid_box-sizing-polyfill-path: '../../box-sizing-polyfill';
 @grid_wrapper-width:            1200px;
 @grid_gutter-width:             30px;
 @grid_total-columns:            12;


### PR DESCRIPTION
This implements the changes discussed in https://github.com/cfpb/capital-framework/issues/151.
## Removals
- Grunt bower task
## Changes
- CSS import paths are now relative.
- `bowerrc` points to `src/vendor` (the now defunct Grunt task used to do this).
- Bumped to `1.0.0`.
- Adjusted CSS paths for the demo pages and regenerated the demos.
## Testing
- You can't. :neutral_face: There's a chicken vs. the egg scenario here. This project's dependencies now point to the 1.x.x version of other CF components. But those versions aren't in Bower/npm yet because their PRs are still pending. This is why Travis is failing.
- The `dev` branch was thoroughly tested prior to this PR and more testing will occur afterward. There will likely be some kinks to work out after this merge but that's okay -- semver will shield current projects from any bugs.
## Review
- @Scotchester 
- @anselmbradford 
